### PR TITLE
Two typos in Sep. 6 notes

### DIFF
--- a/lec/notes/2019-09-06.tex
+++ b/lec/notes/2019-09-06.tex
@@ -253,7 +253,7 @@ the standard $L^2([-1,1])$ inner product is
   \langle p, q \rangle_{L^2([-1,1])} = \int_{-1}^1 p(x) \bar{q}(x) \, dx.
 \]
 If we express $p$ and $q$ with respect to a basis (e.g.~the power
-basis), we fine that we can represent this inner product via a
+basis), we find that we can represent this inner product via a
 symmetric positive definite matrix.  For example,
 let $p(x) = c_0 + c_1 x + c_2 x^2$ and let
 $q(x) = d_0 + d_1 x + d_2 x^2$.  Then

--- a/lec/notes/2019-09-06.tex
+++ b/lec/notes/2019-09-06.tex
@@ -386,7 +386,7 @@ we want
 \]
 One ``obvious'' consistent norm is the {\em Frobenius norm},
 \[
-  A = \sum_{i,j} a_{ij}^2.
+  \|A\|_F = \sqrt{ \sum_{i,j} a_{ij}^2 }.
 \]
 Even more useful are {\em induced norms} (or {\em operator norms})
 \[


### PR DESCRIPTION
One minor typo (fine => find), and one missing norm notation.