### PR TITLE
Typo fixes in 09/06/2019 notes

### DIFF
--- a/lec/notes/2019-09-06.tex
+++ b/lec/notes/2019-09-06.tex
@@ -253,7 +253,7 @@ the standard $L^2([-1,1])$ inner product is
   \langle p, q \rangle_{L^2([-1,1])} = \int_{-1}^1 p(x) \bar{q}(x) \, dx.
 \]
 If we express $p$ and $q$ with respect to a basis (e.g.~the power
-basis), we fine that we can represent this inner product via a
+basis), we find that we can represent this inner product via a
 symmetric positive definite matrix.  For example,
 let $p(x) = c_0 + c_1 x + c_2 x^2$ and let
 $q(x) = d_0 + d_1 x + d_2 x^2$.  Then

--- a/lec/notes/2019-09-06.tex
+++ b/lec/notes/2019-09-06.tex
@@ -83,9 +83,9 @@ independent vectors in $\bbR^n$ is also a basis
   V = \begin{bmatrix} v_1 & v_2 & \ldots & v_n \end{bmatrix}.
 \]
 The matrix $V$ formed in this way is invertible, with multiplication by $V$
-corresponding to a change from the standard basis into the $\{v_j\}$ basis and
-multiplication by $V^{-1}$ corresponding to a map from the $\{v_j\}$ basis to
-the standard basis.
+corresponding to a change from the $\{v_j\}$ basis to the standard basis and
+multiplication by $V^{-1}$ corresponding to a map from the standard basis 
+into the $\{v_j\}$ basis.
 
 We will use matrix-like notation to describe bases and spanning sets
 even when we deal with spaces other than $\bbR^n$.  For example, a

--- a/lec/notes/2019-09-06.tex
+++ b/lec/notes/2019-09-06.tex
@@ -82,10 +82,10 @@ independent vectors in $\bbR^n$ is also a basis
 \[
   V = \begin{bmatrix} v_1 & v_2 & \ldots & v_n \end{bmatrix}.
 \]
-The matrix $V$ formed in this way is invertible, with multiplication
-by $V$ corresponding to a change from the $\{v_j\}$ basis into the
-standard basis and multiplication by $V^{-1}$ corresponding to a map
-from the $\{v_j\}$ basis to the standard basis.
+The matrix $V$ formed in this way is invertible, with multiplication by $V$
+corresponding to a change from the standard basis into the $\{v_j\}$ basis and
+multiplication by $V^{-1}$ corresponding to a map from the $\{v_j\}$ basis to
+the standard basis.
 
 We will use matrix-like notation to describe bases and spanning sets
 even when we deal with spaces other than $\bbR^n$.  For example, a


### PR DESCRIPTION
- One of these, "fine" -> "find", is covered by #2 
- The other typo is that the notes describe the matrix of basis vectors V as changing "from basis v_j to the standard basis", and also describe the matrix V^-1 as mapping "from basis v_j to the standard basis". Unless I'm misreading something, I believe V should be a map from the standard basis to the basis v_j, and the description of V^-1 is correct.